### PR TITLE
Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ new origin is created with arrivals from both origins and then a relocation
 	  message to `scevent` to remove this merged origin. `scevent` selects
       then a new preferred origin and sends a new `EVENT` message (which will
       be received and processed by `scomerger`).
-	- if the preferred origin is from one of the *primary* agency and has an evaluationMode that matches
-    the input.evaluation_mode, `scomerger` merges
-	  the origin from the *primary* agency with the most recent *secondary* one. A new
-	  origin is created with the arrivals of both origins and relocated with
-	  `LOCSAT` (magnitude is not yet updated for the moment).
+	- if the preferred origin is from one of the *primary* agency and has an
+      `evaluationMode` that matches the `input.evaluation_mode`, `scomerger`
+      merges the origin from the *primary* agency with the most recent
+      *secondary* one. A new origin is created with the arrivals of both
+      origins and relocated with `LOCSAT` (magnitude is not yet updated for the
+      moment).
     - `scomerger` send a message to `scevent` to create the new origin in the
 	  database. An `originreference` is created as well to associate the origin
 	  to the event. `scevent` selects also a new preferred origin.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SCOMERGER
 `scomerger` is a seiscomp3 application which aims to merge origins belonging
 to the same event and from 2 differents authors (*primary* and *secondary*). A
 new origin is created with arrivals from both origins and then a relocation
-(LocSAT) is done.
+(LocSAT with iaspei91 profile by default) is done.
 
 `scomerger` works like this:
 
@@ -15,8 +15,9 @@ new origin is created with arrivals from both origins and then a relocation
 	  message to `scevent` to remove this merged origin. `scevent` selects
       then a new preferred origin and sends a new `EVENT` message (which will
       be received and processed by `scomerger`).
-	- if the preferred origin is from the *primary* author, `scomerger` merges
-	  the origin from the *primary* author with the *secondary* one. A new
+	- if the preferred origin is from one of the *primary* agency and has an evaluationMode that matches
+    the input.evaluation_mode, `scomerger` merges
+	  the origin from the *primary* agency with the most recent *secondary* one. A new
 	  origin is created with the arrivals of both origins and relocated with
 	  `LOCSAT` (magnitude is not yet updated for the moment).
     - `scomerger` send a message to `scevent` to create the new origin in the

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Installation
 
     ```bash
     cp descriptions/scomerger.xml /path/to/seiscomp3/etc/descriptions/
+cp defaults/scomerger.cfg /path/to/seiscomp3/etc/defaults/
 cp init/scomerger.py /path/to/seiscomp3/etc/init/
 cp scomerger /path/to/seiscomp3/bin/
     ```

--- a/scomerger/defaults/scomerger.cfg
+++ b/scomerger/defaults/scomerger.cfg
@@ -1,0 +1,8 @@
+# Defines the locator to be used, such as NonLinLoc, Hypo71 or LOCSAT
+locator.type = LOCSAT
+
+# The locator profile to use
+locator.profile = iasp91
+
+# The evaluation mode of the new origin. Can be either "manual" or "automatic".
+output.evaluationMode = automatic

--- a/scomerger/descriptions/scomerger.xml
+++ b/scomerger/descriptions/scomerger.xml
@@ -3,81 +3,81 @@
 	<module name="scomerger" category="Processing">
 		<description>Associates an Origin to an Event or forms a new Event if no match is found. Selects the preferred magnitude.</description>
 		<configuration>
-                    <group name="mode">
-			<parameter name="test" type="boolean" default="false">
-                            <description>
-                                Test mode, do not write object in database.
-                            </description>
-			</parameter>
-                    </group>
-                    <group name="connection">
-                        <parameter name="groupRemove" type="string">
-                            <description>
-                                Defines the group where the module sends the messages to remove origins.
-                            </description>
-                        </parameter>
-                    </group>
-                    <group name="locator">
-                        <parameter name="type" type="string" default="LOCSAT">
-                            <description>
-                                Defines the locator to be used, such as NonLinLoc, Hypo71 or LOCSAT
-                            </description>
-                        </parameter>
-                        <parameter name="profile" type="string" default="iasp91">
-                            <description>
-                                The locator profile to use
-                            </description>
-                        </parameter>
-                        <parameter name="fixedDepth" type="double">
-                            <description>
-                                Fix depth.
-                            </description>
-                        </parameter>
-                        <parameter name="distanceCutOff" type="double">
-                            <description>
-                                Distance cut off.
-                            </description>
-                        </parameter>
-                        <parameter name="ignoreInitialLocation" type="boolean" default="false">
-                            <description>
-                                Ignore initial location.
-                            </description>
-                        </parameter>
-                    </group>
-                    <group name="input">
-                        <parameter name="primaryOriginAgencyIDs" type="list:string">
-                            <description>
-                                Primary agencyID list.
-                            </description>
-                        </parameter>
-                        <parameter name="secondaryOriginAgencyIDs" type="list:string">
-                            <description>
-                                Secondary agencyID list.
-                            </description>
-                        </parameter>
-                        <parameter name="evaluationMode" type="string">
-                            <description>
-                                The evaluation mode of the input origins. Can be either &quot;manual&quot;,  &quot;automatic&quot; or blank.
-                            </description>
-                        </parameter>
-                    </group>
-                    <group name="output">
-                        <parameter name="author" type="string">
-                            <description>
-                                Defines merged origin author.
-                            </description>
-                        </parameter>
-                        <parameter name="agencyID" type="string">
-                            <description>
-                                Defines merged origin agencyID.
-                            </description>
-                        </parameter>
-                        <parameter name="evaluationMode" type="string" default="automatic">
-                            <description>
-                                The evaluation mode of the new origin. Can be either &quot;manual&quot; or &quot;automatic&quot;.
-                            </description>
-                        </parameter>
-                    </group>
+            <group name="mode">
+				<parameter name="test" type="boolean" default="false">
+	                <description>
+	                    Test mode, do not write object in database.
+	                </description>
+				</parameter>
+            </group>
+            <group name="connection">
+                <parameter name="groupRemove" type="string">
+                    <description>
+                        Defines the group where the module sends the messages to remove origins.
+                    </description>
+                </parameter>
+            </group>
+            <group name="locator">
+                <parameter name="type" type="string" default="LOCSAT">
+                    <description>
+                        Defines the locator to be used, such as NonLinLoc, Hypo71 or LOCSAT
+                    </description>
+                </parameter>
+                <parameter name="profile" type="string" default="iasp91">
+                    <description>
+                        The locator profile to use
+                    </description>
+                </parameter>
+                <parameter name="fixedDepth" type="double">
+                    <description>
+                        Fix depth.
+                    </description>
+                </parameter>
+                <parameter name="distanceCutOff" type="double">
+                    <description>
+                        Distance cut off.
+                    </description>
+                </parameter>
+                <parameter name="ignoreInitialLocation" type="boolean" default="false">
+                    <description>
+                        Ignore initial location.
+                    </description>
+                </parameter>
+            </group>
+            <group name="input">
+                <parameter name="primaryOriginAgencyIDs" type="list:string">
+                    <description>
+                        Primary agencyID list.
+                    </description>
+                </parameter>
+                <parameter name="secondaryOriginAgencyIDs" type="list:string">
+                    <description>
+                        Secondary agencyID list.
+                    </description>
+                </parameter>
+                <parameter name="evaluationMode" type="string">
+                    <description>
+                        The evaluation mode of the input origins. Can be either &quot;manual&quot;, &quot;automatic&quot; or blank.
+                    </description>
+                </parameter>
+            </group>
+            <group name="output">
+                <parameter name="author" type="string">
+                    <description>
+                        Defines merged origin author.
+                    </description>
+                </parameter>
+                <parameter name="agencyID" type="string">
+                    <description>
+                        Defines merged origin agencyID.
+                    </description>
+                </parameter>
+                <parameter name="evaluationMode" type="string" default="automatic">
+                    <description>
+                        The evaluation mode of the new origin. Can be either &quot;manual&quot; or &quot;automatic&quot;.
+                    </description>
+                </parameter>
+            </group>
         </configuration>
 		<command-line>
 			<group name="Generic">

--- a/scomerger/descriptions/scomerger.xml
+++ b/scomerger/descriptions/scomerger.xml
@@ -17,25 +17,15 @@
                             </description>
                         </parameter>
                     </group>
-                    <group name="input">
-                        <parameter name="author" type="string">
+                    <group name="locator">
+                        <parameter name="type" type="string" default="LOCSAT">
                             <description>
-                                Defines merged origin author.
+                                Defines the locator to be used, such as NonLinLoc, Hypo71 or LOCSAT
                             </description>
                         </parameter>
-                        <parameter name="primaryOriginAuthors" type="list:string">
+                        <parameter name="profile" type="string" default="iasp91">
                             <description>
-                                Primary author list.
-                            </description>
-                        </parameter>
-                        <parameter name="secondaryOriginAuthors" type="list:string">
-                            <description>
-                                Secondary author list.
-                            </description>
-                        </parameter>
-                        <parameter name="evaluationMode" type="string" default="automatic">
-                            <description>
-                                The evaluation mode of the new origin. Can be either &quot;manual&quot; or &quot;automatic&quot;.
+                                The locator profile to use
                             </description>
                         </parameter>
                         <parameter name="fixedDepth" type="double">
@@ -48,13 +38,47 @@
                                 Distance cut off.
                             </description>
                         </parameter>
-			<parameter name="ignoreInitialLocation" type="boolean" default="false">
+                        <parameter name="ignoreInitialLocation" type="boolean" default="false">
                             <description>
                                 Ignore initial location.
                             </description>
-			</parameter>
+                        </parameter>
                     </group>
-		</configuration>
+                    <group name="input">
+                        <parameter name="primaryOriginAgencyIDs" type="list:string">
+                            <description>
+                                Primary agencyID list.
+                            </description>
+                        </parameter>
+                        <parameter name="secondaryOriginAgencyIDs" type="list:string">
+                            <description>
+                                Secondary agencyID list.
+                            </description>
+                        </parameter>
+                        <parameter name="evaluationMode" type="string">
+                            <description>
+                                The evaluation mode of the input origins. Can be either &quot;manual&quot;,  &quot;automatic&quot; or blank.
+                            </description>
+                        </parameter>
+                    </group>
+                    <group name="output">
+                        <parameter name="author" type="string">
+                            <description>
+                                Defines merged origin author.
+                            </description>
+                        </parameter>
+                        <parameter name="agencyID" type="string">
+                            <description>
+                                Defines merged origin agencyID.
+                            </description>
+                        </parameter>
+                        <parameter name="evaluationMode" type="string" default="automatic">
+                            <description>
+                                The evaluation mode of the new origin. Can be either &quot;manual&quot; or &quot;automatic&quot;.
+                            </description>
+                        </parameter>
+                    </group>
+        </configuration>
 		<command-line>
 			<group name="Generic">
 				<optionReference>generic#help</optionReference>

--- a/scomerger/scomerger
+++ b/scomerger/scomerger
@@ -367,9 +367,6 @@ class OriginMerger(Client.Application):
                 origin_merged = self.db_query.loadObject(type_info, origin_id)
                 origin_merged = DataModel.Origin.Cast(origin_merged)
 
-            if secondary_origin and origin_merged:
-                break
-
         self.secondary_origin = secondary_origin
         self.origin_merged = origin_merged
 

--- a/scomerger/scomerger
+++ b/scomerger/scomerger
@@ -39,13 +39,14 @@ class OriginMerger(Client.Application):
         self.begin_time = None
         self.event_id = None
         self.author = os.path.basename(__file__)
-        self.primary_origin_authors = []
-        self.secondary_origin_authors = []
-        self.evaluation_mode = 'automatic'
+        self.primary_origin_agencyIDs = []
+        self.secondary_origin_agencyIDs = []
+        self.output_evaluation_mode = 'automatic'
+        self.input_evaluation_mode = None
         self.fixed_depth = None
         self.distance_cut_off = None
         self.ignore_initial_location = False
-
+    
     def init(self):
         try:
             if not Client.Application.init(self):
@@ -53,9 +54,24 @@ class OriginMerger(Client.Application):
 
             self.db_query = DataModel.DatabaseQuery(self.database())
 
-            self.locator = Seismology.LocatorInterface.Create('LOCSAT')
+            # Configure locator to be used
+            self.locator = Seismology.LocatorInterface.Create(str(self.locator_type))
+            if not self.locator:
+                Logging.error('Locator ' + self.locator_type + 'not available -> abort')
+                return False
+            
+            # Use this profile with the locator
             self.locator.init(self.configuration())
-
+            self.locator.setProfile(str(self.locator_profile))
+            
+            if self.input_evaluation_mode is not None:
+                if self.input_evaluation_mode.lower() == 'automatic':
+                    self.inputEvaluationMode = DataModel.AUTOMATIC
+                elif self.input_evaluation_mode.lower() == 'manual':
+                    self.inputEvaluationMode = DataModel.MANUAL
+                else:
+                    self.input_evaluation_mode = None
+                
             return True
         except:
             info = traceback.format_exception(*sys.exc_info())
@@ -80,38 +96,58 @@ class OriginMerger(Client.Application):
             except Config.Exception:
                 pass
             try:
-                self.author = self.configGetString('input.author')
+                self.primary_origin_agencyIDs = \
+                    list(self.configGetStrings('input.primaryOriginAgencyIDs'))
             except Config.Exception:
                 pass
             try:
-                self.primary_origin_authors = \
-                    list(self.configGetStrings('input.primaryOriginAuthors'))
+                self.secondary_origin_agencyIDs = \
+                    list(self.configGetStrings('input.secondaryOriginAgencyIDs'))
             except Config.Exception:
                 pass
             try:
-                self.secondary_origin_authors = \
-                    list(self.configGetStrings('input.secondaryOriginAuthors'))
-            except Config.Exception:
-                pass
-            try:
-                self.evaluation_mode = \
+                self.input_evaluation_mode = \
                     self.configGetString('input.evaluationMode')
             except Config.Exception:
                 pass
             try:
-                self.fixed_depth = self.configGetDouble('input.fixedDepth')
+                self.author = self.configGetString('output.author')
+            except Config.Exception:
+                pass
+            try:
+                self.agencyID = self.configGetString('output.agencyID')
+            except Config.Exception:
+                pass
+            try:
+                self.output_evaluation_mode = \
+                    self.configGetString('output.evaluationMode')
+            except Config.Exception:
+                pass
+            try:
+                self.fixed_depth = self.configGetDouble('locator.fixedDepth')
             except Config.Exception:
                 pass
             try:
                 self.distance_cut_off = \
-                    self.configGetDouble('input.distanceCutOff')
+                    self.configGetDouble('locator.distanceCutOff')
             except Config.Exception:
                 pass
             try:
                 self.ignore_initial_location = \
-                    self.configGetBool('input.ignoreInitialLocation')
+                    self.configGetBool('locator.ignoreInitialLocation')
             except Config.Exception:
                 pass
+            try:
+                self.locator_type = \
+                    self.configGetString('locator.type')
+            except Config.Exception:
+                pass
+            try:
+                self.locator_profile = \
+                    self.configGetString('locator.profile')
+            except Config.Exception:
+                pass
+            
 
             return True
         except:
@@ -158,17 +194,25 @@ class OriginMerger(Client.Application):
             'Input',
             'evaluation-mode',
             'origin evaluation mode (manual or automatic)')
-        self.commandline().addGroup('LocSAT')
+        self.commandline().addGroup('locator')
         self.commandline().addStringOption(
-            'LocSAT',
+            'locator',
+            'type',
+            'locator to use')
+        self.commandline().addStringOption(
+            'locator',
+            'profile',
+            'locator profile')
+        self.commandline().addStringOption(
+            'locator',
             'fixed-depth',
             'fix depth')
         self.commandline().addStringOption(
-            'LocSAT',
+            'locator',
             'distance-cut-off',
             'distance cut off')
         self.commandline().addOption(
-            'LocSAT',
+            'locator',
             'ignore-initial-location',
             'ignore initial location')
 
@@ -193,9 +237,15 @@ class OriginMerger(Client.Application):
             if self.commandline().hasOption('author'):
                 self.author = self.commandline().optionString('author')
             if self.commandline().hasOption('evaluation-mode'):
-                self.evaluation_mode = \
+                self.output_evaluation_mode = \
                     self.commandline().optionString('evaluation-mode')
 
+            if self.commandline().hasOption('locator-type'):
+                self.locator_type = \
+                    self.commandline().optionString('locator-type')
+            if self.commandline().hasOption('locator-profile'):
+                self.locator_profile = \
+                    self.commandline().optionString('locator-profile')
             if self.commandline().hasOption('fixed-depth'):
                 fixed_depth = self.commandline().optionString('fixed-depth')
                 self.fixed_depth = float(fixed_depth)
@@ -227,9 +277,19 @@ class OriginMerger(Client.Application):
         preferred_origin = DataModel.Origin.Cast(preferred_origin)
 
         if preferred_origin and preferred_origin.creationInfo():
-            agency = preferred_origin.creationInfo().agencyID()
-            if agency in self.primary_origin_authors:
-                self.primary_origin = preferred_origin
+            agency_id = preferred_origin.creationInfo().agencyID()
+            evaluation_mode = preferred_origin.evaluationMode()
+            if agency_id in self.primary_origin_agencyIDs:
+                if self.input_evaluation_mode is None or  evaluation_mode == self.inputEvaluationMode:
+                    self.primary_origin = preferred_origin
+                    Logging.debug('Origin ' + origin_id + ' qualified for primary origin with agencyID ' + agency_id)
+                else:
+                    if evaluation_mode == DataModel.AUTOMATIC:
+                        Logging.info('Preferred origin not eligible, evaluationMode automatic not allowed')
+                    elif evaluation_mode == DataModel.MANUAL:
+                        Logging.info('Preferred origin not eligible, evaluationMode manual not allowed')
+            else:
+               Logging.info('Preferred origin not eligible, agency ' + agency_id + ' not in PrimaryOriginAgencyIDs')
 
     def _retrieve_secondary_and_merged_origins(self, event):
         """
@@ -252,14 +312,36 @@ class OriginMerger(Client.Application):
             origin_id = origin.publicID()
             agency_id = origin.creationInfo().agencyID()
             author = origin.creationInfo().author()
+            creation_time = origin.creationInfo().creationTime()
+            evaluation_mode = origin.evaluationMode()
+            
+            if origin_id != self.primary_origin.publicID():
+                if self.input_evaluation_mode is None or evaluation_mode == self.inputEvaluationMode:
+                    if agency_id in self.secondary_origin_agencyIDs:
+                        if secondary_origin is None:
+                            secondary_origin = \
+                            self.db_query.loadObject(type_info, origin_id)
+                            secondary_origin = DataModel.Origin.Cast(secondary_origin)
+                            Logging.debug('Origin ' + origin_id + ' qualified for secondary origin with agencyID ' + agency_id)
+                        elif secondary_origin.creationInfo().creationTime().get() < creation_time.get():
+                            Logging.debug('Origin ' + origin_id + ' qualified for secondary origin with agencyID ' + agency_id)
+                            Logging.debug(' replace ' + secondary_origin.publicID())
+                            secondary_origin = \
+                            self.db_query.loadObject(type_info, origin_id)
+                            secondary_origin = DataModel.Origin.Cast(secondary_origin)
+                        else:
+                            Logging.debug('Origin ' + origin_id + ' earlier than already qualified origin ' + secondary_origin.publicID())
+                    else:
+                        Logging.debug('Origin ' + origin_id + ' failed to qualify : wrong agencyID ' + agency_id)
+                else:
+                    if evaluation_mode == DataModel.AUTOMATIC:
+                        Logging.info('Origin not eligible, evaluationMode automatic not allowed')
+                    elif evaluation_mode == DataModel.MANUAL:
+                        Logging.info('Origin not eligible, evaluationMode manual not allowed')                 
+            else:
+                    Logging.debug('Origin ' + origin_id + ' already qualified for primary origin')                
 
-            if secondary_origin is None and \
-                    agency_id in self.secondary_origin_authors:
-                secondary_origin = \
-                    self.db_query.loadObject(type_info, origin_id)
-                secondary_origin = DataModel.Origin.Cast(secondary_origin)
-
-            if origin_merged is None and author == self.author:
+            if origin_merged is None and author == self.author and agency_id == self.agencyID:
                 origin_merged = self.db_query.loadObject(type_info, origin_id)
                 origin_merged = DataModel.Origin.Cast(origin_merged)
 
@@ -347,6 +429,11 @@ class OriginMerger(Client.Application):
         Get the primary and secondary origins and return a new origin with the
         Arrivals, Magnitude and StationMagnitude of both origins.
         """
+        self._retrieve_primary_origin(event)
+        if not self.primary_origin:
+            Logging.warning('No primary origin found')
+            return None
+
         self._retrieve_secondary_and_merged_origins(event)
         if self.origin_merged:
             if self.remove_merged_origin:
@@ -370,10 +457,7 @@ class OriginMerger(Client.Application):
             return None
 
         if not self.secondary_origin:
-            return None
-
-        self._retrieve_primary_origin(event)
-        if not self.primary_origin:
+            Logging.warning('No secondary origin found')
             return None
 
         new_origin = DataModel.Origin(self.primary_origin)
@@ -422,7 +506,6 @@ class OriginMerger(Client.Application):
             self.db_query.load(inv.network(i))
 
         # Prepare the locator
-        self.locator.setProfile(origin.earthModelID())
         fixed_depth = self.fixed_depth
         depth_uncertainty = None
         try:
@@ -450,13 +533,12 @@ class OriginMerger(Client.Application):
             return None
 
         # There are some modifications to do on the generated origin
-        agency = origin.creationInfo().agencyID()
-        new_origin.creationInfo().setAgencyID(agency)
+        new_origin.creationInfo().setAgencyID(self.agencyID)
         new_origin.creationInfo().setAuthor(self.author)
 
-        if self.evaluation_mode.lower() == 'automatic':
+        if self.output_evaluation_mode.lower() == 'automatic':
             new_origin.setEvaluationMode(DataModel.AUTOMATIC)
-        elif self.evaluation_mode.lower() == 'manual':
+        elif self.output_evaluation_mode.lower() == 'manual':
             new_origin.setEvaluationMode(DataModel.MANUAL)
 
         new_origin.setEvaluationStatus(DataModel.PRELIMINARY)

--- a/scomerger/scomerger
+++ b/scomerger/scomerger
@@ -46,7 +46,7 @@ class OriginMerger(Client.Application):
         self.fixed_depth = None
         self.distance_cut_off = None
         self.ignore_initial_location = False
-    
+
     def init(self):
         try:
             if not Client.Application.init(self):
@@ -55,15 +55,17 @@ class OriginMerger(Client.Application):
             self.db_query = DataModel.DatabaseQuery(self.database())
 
             # Configure locator to be used
-            self.locator = Seismology.LocatorInterface.Create(str(self.locator_type))
+            self.locator = \
+                Seismology.LocatorInterface.Create(self.locator_type)
             if not self.locator:
-                Logging.error('Locator ' + self.locator_type + 'not available -> abort')
+                Logging.error('Locator %s not available -> abort'
+                              % self.locator_type)
                 return False
-            
+
             # Use this profile with the locator
             self.locator.init(self.configuration())
-            self.locator.setProfile(str(self.locator_profile))
-            
+            self.locator.setProfile(self.locator_profile)
+
             if self.input_evaluation_mode is not None:
                 if self.input_evaluation_mode.lower() == 'automatic':
                     self.inputEvaluationMode = DataModel.AUTOMATIC
@@ -71,7 +73,7 @@ class OriginMerger(Client.Application):
                     self.inputEvaluationMode = DataModel.MANUAL
                 else:
                     self.input_evaluation_mode = None
-                
+
             return True
         except:
             info = traceback.format_exception(*sys.exc_info())
@@ -101,8 +103,9 @@ class OriginMerger(Client.Application):
             except Config.Exception:
                 pass
             try:
-                self.secondary_origin_agencyIDs = \
-                    list(self.configGetStrings('input.secondaryOriginAgencyIDs'))
+                self.secondary_origin_agencyIDs = list(
+                    self.configGetStrings('input.secondaryOriginAgencyIDs')
+                )
             except Config.Exception:
                 pass
             try:
@@ -147,7 +150,6 @@ class OriginMerger(Client.Application):
                     self.configGetString('locator.profile')
             except Config.Exception:
                 pass
-            
 
             return True
         except:
@@ -280,16 +282,21 @@ class OriginMerger(Client.Application):
             agency_id = preferred_origin.creationInfo().agencyID()
             evaluation_mode = preferred_origin.evaluationMode()
             if agency_id in self.primary_origin_agencyIDs:
-                if self.input_evaluation_mode is None or  evaluation_mode == self.inputEvaluationMode:
+                if (self.input_evaluation_mode is None or
+                        evaluation_mode == self.inputEvaluationMode):
                     self.primary_origin = preferred_origin
-                    Logging.debug('Origin ' + origin_id + ' qualified for primary origin with agencyID ' + agency_id)
+                    Logging.debug('Origin %s qualified for primary origin '
+                                  'with agencyID %s' % (origin_id, agency_id))
                 else:
                     if evaluation_mode == DataModel.AUTOMATIC:
-                        Logging.info('Preferred origin not eligible, evaluationMode automatic not allowed')
+                        Logging.info('Preferred origin not eligible, '
+                                     'evaluationMode automatic not allowed')
                     elif evaluation_mode == DataModel.MANUAL:
-                        Logging.info('Preferred origin not eligible, evaluationMode manual not allowed')
+                        Logging.info('Preferred origin not eligible, '
+                                     'evaluationMode manual not allowed')
             else:
-               Logging.info('Preferred origin not eligible, agency ' + agency_id + ' not in PrimaryOriginAgencyIDs')
+                Logging.info('Preferred origin not eligible, agency %s not in '
+                             'PrimaryOriginAgencyIDs' % agency_id)
 
     def _retrieve_secondary_and_merged_origins(self, event):
         """
@@ -314,34 +321,51 @@ class OriginMerger(Client.Application):
             author = origin.creationInfo().author()
             creation_time = origin.creationInfo().creationTime()
             evaluation_mode = origin.evaluationMode()
-            
+
             if origin_id != self.primary_origin.publicID():
-                if self.input_evaluation_mode is None or evaluation_mode == self.inputEvaluationMode:
+                if (self.input_evaluation_mode is None or
+                        evaluation_mode == self.inputEvaluationMode):
                     if agency_id in self.secondary_origin_agencyIDs:
                         if secondary_origin is None:
                             secondary_origin = \
-                            self.db_query.loadObject(type_info, origin_id)
-                            secondary_origin = DataModel.Origin.Cast(secondary_origin)
-                            Logging.debug('Origin ' + origin_id + ' qualified for secondary origin with agencyID ' + agency_id)
-                        elif secondary_origin.creationInfo().creationTime().get() < creation_time.get():
-                            Logging.debug('Origin ' + origin_id + ' qualified for secondary origin with agencyID ' + agency_id)
-                            Logging.debug(' replace ' + secondary_origin.publicID())
+                                self.db_query.loadObject(type_info, origin_id)
                             secondary_origin = \
-                            self.db_query.loadObject(type_info, origin_id)
-                            secondary_origin = DataModel.Origin.Cast(secondary_origin)
+                                DataModel.Origin.Cast(secondary_origin)
+                            Logging.debug('Origin %s qualified for secondary '
+                                          'origin with agencyID %s'
+                                          % (origin_id, agency_id))
+                        elif (secondary_origin.creationInfo().creationTime().get()
+                                < creation_time.get()):
+                            Logging.debug('Origin %s qualified for secondary '
+                                          'origin with agencyID %s'
+                                          % (origin_id, agency_id))
+                            Logging.debug(' replace %s'
+                                          % secondary_origin.publicID())
+                            secondary_origin = \
+                                self.db_query.loadObject(type_info, origin_id)
+                            secondary_origin = \
+                                DataModel.Origin.Cast(secondary_origin)
                         else:
-                            Logging.debug('Origin ' + origin_id + ' earlier than already qualified origin ' + secondary_origin.publicID())
+                            Logging.debug('Origin %s earlier than already '
+                                          'qualified origin %s'
+                                          % (origin_id,
+                                             secondary_origin.publicID()))
                     else:
-                        Logging.debug('Origin ' + origin_id + ' failed to qualify : wrong agencyID ' + agency_id)
+                        Logging.debug('Origin %s failed to qualify: wrong '
+                                      'agencyID %s' % (origin_id, agency_id))
                 else:
                     if evaluation_mode == DataModel.AUTOMATIC:
-                        Logging.info('Origin not eligible, evaluationMode automatic not allowed')
+                        Logging.info('Origin not eligible, evaluationMode '
+                                     'automatic not allowed')
                     elif evaluation_mode == DataModel.MANUAL:
-                        Logging.info('Origin not eligible, evaluationMode manual not allowed')                 
+                        Logging.info('Origin not eligible, evaluationMode '
+                                     'manual not allowed')
             else:
-                    Logging.debug('Origin ' + origin_id + ' already qualified for primary origin')                
+                    Logging.debug('Origin %s already qualified for primary '
+                                  'origin' % origin_id)
 
-            if origin_merged is None and author == self.author and agency_id == self.agencyID:
+            if (origin_merged is None and author == self.author and
+                    agency_id == self.agencyID):
                 origin_merged = self.db_query.loadObject(type_info, origin_id)
                 origin_merged = DataModel.Origin.Cast(origin_merged)
 

--- a/scomerger/scomerger
+++ b/scomerger/scomerger
@@ -17,6 +17,12 @@ class OriginMerger(Client.Application):
     Merge 2 origins inside events by author names.
     """
 
+    # Convert an evaluation mode string to the correct enum
+    EVALUATION_MODES = {
+        'automatic': DataModel.AUTOMATIC,
+        'manual': DataModel.MANUAL,
+    }
+
     def __init__(self, argc, argv):
         Client.Application.__init__(self, argc, argv)
         self.setMessagingEnabled(True)
@@ -66,14 +72,6 @@ class OriginMerger(Client.Application):
             self.locator.init(self.configuration())
             self.locator.setProfile(self.locator_profile)
 
-            if self.input_evaluation_mode is not None:
-                if self.input_evaluation_mode.lower() == 'automatic':
-                    self.inputEvaluationMode = DataModel.AUTOMATIC
-                elif self.input_evaluation_mode.lower() == 'manual':
-                    self.inputEvaluationMode = DataModel.MANUAL
-                else:
-                    self.input_evaluation_mode = None
-
             return True
         except:
             info = traceback.format_exception(*sys.exc_info())
@@ -109,9 +107,11 @@ class OriginMerger(Client.Application):
             except Config.Exception:
                 pass
             try:
+
+                mode = self.configGetString('input.evaluationMode')
                 self.input_evaluation_mode = \
-                    self.configGetString('input.evaluationMode')
-            except Config.Exception:
+                    OriginMerger.EVALUATION_MODES[mode.lower()]
+            except (Config.Exception, KeyError):
                 pass
             try:
                 self.author = self.configGetString('output.author')
@@ -283,17 +283,16 @@ class OriginMerger(Client.Application):
             evaluation_mode = preferred_origin.evaluationMode()
             if agency_id in self.primary_origin_agencyIDs:
                 if (self.input_evaluation_mode is None or
-                        evaluation_mode == self.inputEvaluationMode):
+                        evaluation_mode == self.input_evaluation_mode):
                     self.primary_origin = preferred_origin
                     Logging.debug('Origin %s qualified for primary origin '
                                   'with agencyID %s' % (origin_id, agency_id))
-                else:
-                    if evaluation_mode == DataModel.AUTOMATIC:
-                        Logging.info('Preferred origin not eligible, '
-                                     'evaluationMode automatic not allowed')
-                    elif evaluation_mode == DataModel.MANUAL:
-                        Logging.info('Preferred origin not eligible, '
-                                     'evaluationMode manual not allowed')
+                elif evaluation_mode == DataModel.AUTOMATIC:
+                    Logging.info('Preferred origin not eligible, '
+                                 'evaluationMode automatic not allowed')
+                elif evaluation_mode == DataModel.MANUAL:
+                    Logging.info('Preferred origin not eligible, '
+                                 'evaluationMode manual not allowed')
             else:
                 Logging.info('Preferred origin not eligible, agency %s not in '
                              'PrimaryOriginAgencyIDs' % agency_id)
@@ -324,7 +323,7 @@ class OriginMerger(Client.Application):
 
             if origin_id != self.primary_origin.publicID():
                 if (self.input_evaluation_mode is None or
-                        evaluation_mode == self.inputEvaluationMode):
+                        evaluation_mode == self.input_evaluation_mode):
                     if agency_id in self.secondary_origin_agencyIDs:
                         if secondary_origin is None:
                             secondary_origin = \
@@ -353,13 +352,12 @@ class OriginMerger(Client.Application):
                     else:
                         Logging.debug('Origin %s failed to qualify: wrong '
                                       'agencyID %s' % (origin_id, agency_id))
-                else:
-                    if evaluation_mode == DataModel.AUTOMATIC:
-                        Logging.info('Origin not eligible, evaluationMode '
-                                     'automatic not allowed')
-                    elif evaluation_mode == DataModel.MANUAL:
-                        Logging.info('Origin not eligible, evaluationMode '
-                                     'manual not allowed')
+                elif evaluation_mode == DataModel.AUTOMATIC:
+                    Logging.info('Origin not eligible, evaluationMode '
+                                 'automatic not allowed')
+                elif evaluation_mode == DataModel.MANUAL:
+                    Logging.info('Origin not eligible, evaluationMode '
+                                 'manual not allowed')
             else:
                     Logging.debug('Origin %s already qualified for primary '
                                   'origin' % origin_id)


### PR DESCRIPTION
Added the capability to use whatever available locator and its profile for relocation.

Added the possibility the origins by evaluationMode.

Choose the latest origin that passed the filters as the secondary Origin.

The primary origin agencyIDs can also be included in the secondary origin agencyIDs.

Updated the README